### PR TITLE
Update dependencies and improve build process

### DIFF
--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -43,8 +43,9 @@ Future<void> createCommand(ArgResults command) async {
     interactive,
     'flame-version',
     'Which Flame version do you wish to use?',
-    flameVersions.versions.associateWith((e) => e),
+    flameVersions.visible.associateWith((e) => e),
     defaultsTo: flameVersions.versions.first,
+    fullOptions: flameVersions.versions.associateWith((e) => e),
   );
 
   final extraPackageOptions = FlameVersionManager.singleton.versions.keys

--- a/lib/flame_version_manager.dart
+++ b/lib/flame_version_manager.dart
@@ -67,11 +67,14 @@ enum Package {
 
 class Versions {
   final List<String> versions;
+
   String get main => versions.first;
+  List<String> get visible => versions.take(5).toList();
+
   const Versions(this.versions);
 
   factory Versions.parse(List<Map<String, dynamic>> json) {
     final versions = json.map((e) => e['version'] as String).toList().reversed;
-    return Versions(versions.take(3).toList());
+    return Versions(versions.toList());
   }
 }

--- a/lib/templates/bricks/basics_bundle.dart
+++ b/lib/templates/bricks/basics_bundle.dart
@@ -1,6 +1,48 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
+// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
 
 import 'package:mason/mason.dart';
 
-final basicsBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"},{"path":"test/widget_test.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K","type":"text"}],"hooks":[],"name":"basics","description":"The basic structure that most games will require. No boilerplate required, but no extra fluff.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});
+final basicsBundle = MasonBundle.fromJson(<String, dynamic>{
+  "files": [
+    {
+      "path": "analysis_options.yaml",
+      "data":
+          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
+      "type": "text"
+    },
+    {
+      "path": "lib/main.dart",
+      "data":
+          "aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=",
+      "type": "text"
+    },
+    {
+      "path": "pubspec.yaml",
+      "data":
+          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
+      "type": "text"
+    },
+    {
+      "path": "test/widget_test.dart",
+      "data":
+          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K",
+      "type": "text"
+    }
+  ],
+  "hooks": [],
+  "name": "basics",
+  "description":
+      "The basic structure that most games will require. No boilerplate required, but no extra fluff.",
+  "version": "0.1.0",
+  "environment": {"mason": "any"},
+  "vars": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "version": {"type": "string"},
+    "flame-version": {"type": "string"},
+    "flame-lint-version": {"type": "string"},
+    "extra-dependencies": {"type": "array"},
+    "extra-dev-dependencies": {"type": "array"}
+  }
+});

--- a/lib/templates/bricks/basics_bundle.dart
+++ b/lib/templates/bricks/basics_bundle.dart
@@ -1,48 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
+// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
 
 import 'package:mason/mason.dart';
 
-final basicsBundle = MasonBundle.fromJson(<String, dynamic>{
-  "files": [
-    {
-      "path": "analysis_options.yaml",
-      "data":
-          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
-      "type": "text"
-    },
-    {
-      "path": "lib/main.dart",
-      "data":
-          "aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=",
-      "type": "text"
-    },
-    {
-      "path": "pubspec.yaml",
-      "data":
-          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
-      "type": "text"
-    },
-    {
-      "path": "test/widget_test.dart",
-      "data":
-          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K",
-      "type": "text"
-    }
-  ],
-  "hooks": [],
-  "name": "basics",
-  "description":
-      "The basic structure that most games will require. No boilerplate required, but no extra fluff.",
-  "version": "0.1.0",
-  "environment": {"mason": "any"},
-  "vars": {
-    "name": {"type": "string"},
-    "description": {"type": "string"},
-    "version": {"type": "string"},
-    "flame-version": {"type": "string"},
-    "flame-lint-version": {"type": "string"},
-    "extra-dependencies": {"type": "array"},
-    "extra-dev-dependencies": {"type": "array"}
-  }
-});
+final basicsBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"},{"path":"test/widget_test.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K","type":"text"}],"hooks":[],"name":"basics","description":"The basic structure that most games will require. No boilerplate required, but no extra fluff.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});

--- a/lib/templates/bricks/example_bundle.dart
+++ b/lib/templates/bricks/example_bundle.dart
@@ -1,6 +1,48 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
+// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
 
 import 'package:mason/mason.dart';
 
-final exampleBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"},{"path":"test/widget_test.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K","type":"text"}],"hooks":[],"name":"example","description":"An actual complete, working game example. Extra code that you won't need but will teach you how to wire the most important pieces.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});
+final exampleBundle = MasonBundle.fromJson(<String, dynamic>{
+  "files": [
+    {
+      "path": "analysis_options.yaml",
+      "data":
+          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
+      "type": "text"
+    },
+    {
+      "path": "lib/main.dart",
+      "data":
+          "aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=",
+      "type": "text"
+    },
+    {
+      "path": "pubspec.yaml",
+      "data":
+          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
+      "type": "text"
+    },
+    {
+      "path": "test/widget_test.dart",
+      "data":
+          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K",
+      "type": "text"
+    }
+  ],
+  "hooks": [],
+  "name": "example",
+  "description":
+      "An actual complete, working game example. Extra code that you won't need but will teach you how to wire the most important pieces.",
+  "version": "0.1.0",
+  "environment": {"mason": "any"},
+  "vars": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "version": {"type": "string"},
+    "flame-version": {"type": "string"},
+    "flame-lint-version": {"type": "string"},
+    "extra-dependencies": {"type": "array"},
+    "extra-dev-dependencies": {"type": "array"}
+  }
+});

--- a/lib/templates/bricks/example_bundle.dart
+++ b/lib/templates/bricks/example_bundle.dart
@@ -1,48 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
+// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
 
 import 'package:mason/mason.dart';
 
-final exampleBundle = MasonBundle.fromJson(<String, dynamic>{
-  "files": [
-    {
-      "path": "analysis_options.yaml",
-      "data":
-          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
-      "type": "text"
-    },
-    {
-      "path": "lib/main.dart",
-      "data":
-          "aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=",
-      "type": "text"
-    },
-    {
-      "path": "pubspec.yaml",
-      "data":
-          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
-      "type": "text"
-    },
-    {
-      "path": "test/widget_test.dart",
-      "data":
-          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K",
-      "type": "text"
-    }
-  ],
-  "hooks": [],
-  "name": "example",
-  "description":
-      "An actual complete, working game example. Extra code that you won't need but will teach you how to wire the most important pieces.",
-  "version": "0.1.0",
-  "environment": {"mason": "any"},
-  "vars": {
-    "name": {"type": "string"},
-    "description": {"type": "string"},
-    "version": {"type": "string"},
-    "flame-version": {"type": "string"},
-    "flame-lint-version": {"type": "string"},
-    "extra-dependencies": {"type": "array"},
-    "extra-dev-dependencies": {"type": "array"}
-  }
-});
+final exampleBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdkYXJ0Om1hdGgnOwoKaW1wb3J0ICdwYWNrYWdlOmZsYW1lL2NvbXBvbmVudHMuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9nYW1lLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6ZmxhbWUvaW5wdXQuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZS9wYWxldHRlLmRhcnQnOwppbXBvcnQgJ3BhY2thZ2U6Zmx1dHRlci9tYXRlcmlhbC5kYXJ0JzsKCmZpbmFsIF9ybmcgPSBSYW5kb20oKTsKCnZvaWQgbWFpbigpIHsKICBydW5BcHAoR2FtZVdpZGdldChnYW1lOiBNeUdhbWUoKSkpOwp9CgpjbGFzcyBNeUNvbXBvbmVudCBleHRlbmRzIFBvc2l0aW9uQ29tcG9uZW50IHdpdGggSGFzR2FtZVJlZjxNeUdhbWU+IHsKICBzdGF0aWMgZmluYWwgX3BhaW50ID0gQmFzaWNQYWxldHRlLndoaXRlLnBhaW50KCk7CiAgZmluYWwgVmVjdG9yMiBzcGVlZCA9IFZlY3RvcjIuemVybygpOwoKICBAb3ZlcnJpZGUKICBAb3ZlcnJpZGUKICBGdXR1cmU8dm9pZD4gb25Mb2FkKCkgYXN5bmMgewogICAgYW5jaG9yID0gQW5jaG9yLmNlbnRlcjsKICAgIHBvc2l0aW9uID0gZ2FtZVJlZi5zaXplIC8gMjsKICB9CgogIEBvdmVycmlkZQogIHZvaWQgcmVuZGVyKENhbnZhcyBjKSB7CiAgICBjLmRyYXdSZWN0KHNpemUudG9SZWN0KCksIF9wYWludCk7CiAgfQoKICBAb3ZlcnJpZGUKICB2b2lkIHVwZGF0ZShkb3VibGUgZHQpIHsKICAgIHBvc2l0aW9uICs9IHNwZWVkICogZHQ7CiAgfQp9CgpjbGFzcyBNeUdhbWUgZXh0ZW5kcyBGbGFtZUdhbWUgd2l0aCBUYXBEZXRlY3RvciB7CiAgbGF0ZSBmaW5hbCBNeUNvbXBvbmVudCBteUNvbXBvbmVudDsKCiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIGF3YWl0IGFkZChteUNvbXBvbmVudCA9IE15Q29tcG9uZW50KCkpOwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KCiAgQG92ZXJyaWRlCiAgdm9pZCBvblRhcCgpIHsKICAgIG15Q29tcG9uZW50LnNwZWVkLnggPSAtNSArIDEwICogX3JuZy5uZXh0RG91YmxlKCk7CiAgICBteUNvbXBvbmVudC5zcGVlZC55ID0gLTUgKyAxMCAqIF9ybmcubmV4dERvdWJsZSgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"},{"path":"test/widget_test.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbGFtZV90ZXN0L2ZsYW1lX3Rlc3QuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyX3Rlc3QvZmx1dHRlcl90ZXN0LmRhcnQnOwoKaW1wb3J0ICdwYWNrYWdlOnt7bmFtZX19L21haW4uZGFydCc7CgpmaW5hbCBteUdhbWUgPSBGbGFtZVRlc3RlcihNeUdhbWUubmV3KTsKCnZvaWQgbWFpbigpIHsKICBteUdhbWUudGVzdEdhbWVXaWRnZXQoCiAgICAnZ2FtZSB3aWxsIGxvYWQgaXRzIGNoaWxkJywKICAgIHZlcmlmeTogKGdhbWUsIHRlc3RlcikgYXN5bmMgewogICAgICBnYW1lLnVwZGF0ZSgwLjApOwoKICAgICAgZXhwZWN0KGdhbWUuY2hpbGRyZW4ubGVuZ3RoLCAxKTsKICAgICAgZXhwZWN0KGdhbWUubXlDb21wb25lbnQuc3BlZWQsIFZlY3RvcjIuemVybygpKTsKCiAgICAgIGF3YWl0IHRlc3Rlci50YXBBdChjb25zdCBPZmZzZXQoMTAsIDEwKSk7CiAgICAgIGV4cGVjdChnYW1lLm15Q29tcG9uZW50LnNwZWVkLCBpc05vdChlcXVhbHMoVmVjdG9yMi56ZXJvKCkpKSk7CiAgICB9LAogICk7Cn0K","type":"text"}],"hooks":[],"name":"example","description":"An actual complete, working game example. Extra code that you won't need but will teach you how to wire the most important pieces.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});

--- a/lib/templates/bricks/simple_bundle.dart
+++ b/lib/templates/bricks/simple_bundle.dart
@@ -1,6 +1,42 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
+// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
 
 import 'package:mason/mason.dart';
 
-final simpleBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyL21hdGVyaWFsLmRhcnQnOwoKdm9pZCBtYWluKCkgewogIHJ1bkFwcChHYW1lV2lkZ2V0KGdhbWU6IE15R2FtZSgpKSk7Cn0KCmNsYXNzIE15R2FtZSBleHRlbmRzIEZsYW1lR2FtZSB7CiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIC8vIFRPRE8gYWRkIHlvdXIgbG9hZCBsb2dpYwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"}],"hooks":[],"name":"simple","description":"An empty Flame project with just the bare minimums to get you up and running.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});
+final simpleBundle = MasonBundle.fromJson(<String, dynamic>{
+  "files": [
+    {
+      "path": "analysis_options.yaml",
+      "data":
+          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
+      "type": "text"
+    },
+    {
+      "path": "lib/main.dart",
+      "data":
+          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyL21hdGVyaWFsLmRhcnQnOwoKdm9pZCBtYWluKCkgewogIHJ1bkFwcChHYW1lV2lkZ2V0KGdhbWU6IE15R2FtZSgpKSk7Cn0KCmNsYXNzIE15R2FtZSBleHRlbmRzIEZsYW1lR2FtZSB7CiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIC8vIFRPRE8gYWRkIHlvdXIgbG9hZCBsb2dpYwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KfQo=",
+      "type": "text"
+    },
+    {
+      "path": "pubspec.yaml",
+      "data":
+          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
+      "type": "text"
+    }
+  ],
+  "hooks": [],
+  "name": "simple",
+  "description":
+      "An empty Flame project with just the bare minimums to get you up and running.",
+  "version": "0.1.0",
+  "environment": {"mason": "any"},
+  "vars": {
+    "name": {"type": "string"},
+    "description": {"type": "string"},
+    "version": {"type": "string"},
+    "flame-version": {"type": "string"},
+    "flame-lint-version": {"type": "string"},
+    "extra-dependencies": {"type": "array"},
+    "extra-dev-dependencies": {"type": "array"}
+  }
+});

--- a/lib/templates/bricks/simple_bundle.dart
+++ b/lib/templates/bricks/simple_bundle.dart
@@ -1,42 +1,6 @@
 // GENERATED CODE - DO NOT MODIFY BY HAND
-// ignore_for_file: prefer_single_quotes, public_member_api_docs, lines_longer_than_80_chars, implicit_dynamic_list_literal, implicit_dynamic_map_literal
+// ignore_for_file: type=lint, implicit_dynamic_list_literal, implicit_dynamic_map_literal, inference_failure_on_collection_literal
 
 import 'package:mason/mason.dart';
 
-final simpleBundle = MasonBundle.fromJson(<String, dynamic>{
-  "files": [
-    {
-      "path": "analysis_options.yaml",
-      "data":
-          "aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==",
-      "type": "text"
-    },
-    {
-      "path": "lib/main.dart",
-      "data":
-          "aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyL21hdGVyaWFsLmRhcnQnOwoKdm9pZCBtYWluKCkgewogIHJ1bkFwcChHYW1lV2lkZ2V0KGdhbWU6IE15R2FtZSgpKSk7Cn0KCmNsYXNzIE15R2FtZSBleHRlbmRzIEZsYW1lR2FtZSB7CiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIC8vIFRPRE8gYWRkIHlvdXIgbG9hZCBsb2dpYwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KfQo=",
-      "type": "text"
-    },
-    {
-      "path": "pubspec.yaml",
-      "data":
-          "bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=",
-      "type": "text"
-    }
-  ],
-  "hooks": [],
-  "name": "simple",
-  "description":
-      "An empty Flame project with just the bare minimums to get you up and running.",
-  "version": "0.1.0",
-  "environment": {"mason": "any"},
-  "vars": {
-    "name": {"type": "string"},
-    "description": {"type": "string"},
-    "version": {"type": "string"},
-    "flame-version": {"type": "string"},
-    "flame-lint-version": {"type": "string"},
-    "extra-dependencies": {"type": "array"},
-    "extra-dev-dependencies": {"type": "array"}
-  }
-});
+final simpleBundle = MasonBundle.fromJson(<String, dynamic>{"files":[{"path":"analysis_options.yaml","data":"aW5jbHVkZTogcGFja2FnZTpmbGFtZV9saW50L2FuYWx5c2lzX29wdGlvbnMueWFtbA==","type":"text"},{"path":"lib/main.dart","data":"aW1wb3J0ICdwYWNrYWdlOmZsYW1lL2dhbWUuZGFydCc7CmltcG9ydCAncGFja2FnZTpmbHV0dGVyL21hdGVyaWFsLmRhcnQnOwoKdm9pZCBtYWluKCkgewogIHJ1bkFwcChHYW1lV2lkZ2V0KGdhbWU6IE15R2FtZSgpKSk7Cn0KCmNsYXNzIE15R2FtZSBleHRlbmRzIEZsYW1lR2FtZSB7CiAgQG92ZXJyaWRlCiAgRnV0dXJlPHZvaWQ+IG9uTG9hZCgpIGFzeW5jIHsKICAgIC8vIFRPRE8gYWRkIHlvdXIgbG9hZCBsb2dpYwogICAgcmV0dXJuIHN1cGVyLm9uTG9hZCgpOwogIH0KfQo=","type":"text"},{"path":"pubspec.yaml","data":"bmFtZToge3tuYW1lfX0KZGVzY3JpcHRpb246IHt7ZGVzY3JpcHRpb259fQp2ZXJzaW9uOiB7e3ZlcnNpb259fQoKcHVibGlzaF90bzogJ25vbmUnCgplbnZpcm9ubWVudDoKICBzZGs6ICI+PTIuMTcuMCA8My4wLjAiCgpkZXBlbmRlbmNpZXM6CiAgZmx1dHRlcjoKICAgIHNkazogZmx1dHRlcnt7I2V4dHJhLWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGVwZW5kZW5jaWVzfX0KCmRldl9kZXBlbmRlbmNpZXM6e3sjZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAge3tuYW1lfX06IHt7dmVyc2lvbn19e3svZXh0cmEtZGV2LWRlcGVuZGVuY2llc319CiAgZmx1dHRlcl90ZXN0OgogICAgc2RrOiBmbHV0dGVyCiAgaW50ZWdyYXRpb25fdGVzdDoKICAgIHNkazogZmx1dHRlcgoKZmx1dHRlcjoKICB1c2VzLW1hdGVyaWFsLWRlc2lnbjogZmFsc2U=","type":"text"}],"hooks":[],"name":"simple","description":"An empty Flame project with just the bare minimums to get you up and running.","version":"0.1.0","environment":{"mason":"any"},"vars":{"name":{"type":"string"},"description":{"type":"string"},"version":{"type":"string"},"flame-version":{"type":"string"},"flame-lint-version":{"type":"string"},"extra-dependencies":{"type":"array"},"extra-dev-dependencies":{"type":"array"}}});

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -45,6 +45,7 @@ String getOption(
   Map<String, String> options, {
   String? desc,
   String? defaultsTo,
+  Map<String, String> fullOptions = const {},
 }) {
   var value = results[name] as String?;
   if (!isInteractive) {
@@ -57,7 +58,8 @@ String getOption(
       }
     }
   }
-  if (value != null && !options.values.contains(value)) {
+  final fullValues = {...options, ...fullOptions}.values;
+  if (value != null && !fullValues.contains(value)) {
     print('Invalid value $value provided. Must be in: ${options.values}');
     value = null;
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -133,7 +133,7 @@ packages:
       name: flame_lint
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.1.1"
+    version: "0.2.0"
   glob:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -5,456 +5,593 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      url: "https://pub.dartlang.org"
+      sha256: "0c80aeab9bc807ab10022cd3b2f4cf2ecdf231949dc1ddd9442406a003f19201"
+      url: "https://pub.dev"
     source: hosted
-    version: "21.0.0"
+    version: "52.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      url: "https://pub.dartlang.org"
+      sha256: cd8ee83568a77f3ae6b913a36093a1c9b1264e7cb7f834d9ddd2311dade9c1f4
+      url: "https://pub.dev"
     source: hosted
-    version: "1.5.0"
+    version: "5.4.0"
   archive:
     dependency: transitive
     description:
       name: archive
-      url: "https://pub.dartlang.org"
+      sha256: d6347d54a2d8028e0437e3c099f66fdb8ae02c4720c1e7534c9f24c10351f85d
+      url: "https://pub.dev"
     source: hosted
-    version: "3.3.1"
+    version: "3.3.6"
   args:
     dependency: "direct main"
     description:
       name: args
-      url: "https://pub.dartlang.org"
+      sha256: "139d809800a412ebb26a3892da228b2d0ba36f0ef5d9a82166e5e52ec8d61611"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.3.2"
   async:
     dependency: transitive
     description:
       name: async
-      url: "https://pub.dartlang.org"
+      sha256: bfe67ef28df125b7dddcea62755991f807aa39a2492a23e1550161692950bbe0
+      url: "https://pub.dev"
     source: hosted
-    version: "2.5.0"
+    version: "2.10.0"
   boolean_selector:
     dependency: transitive
     description:
       name: boolean_selector
-      url: "https://pub.dartlang.org"
+      sha256: "6cfb5af12253eaf2b368f07bacc5a80d1301a071c73360d746b7f2e32d762c66"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   charcode:
     dependency: "direct main"
     description:
       name: charcode
-      url: "https://pub.dartlang.org"
+      sha256: fb98c0f6d12c920a02ee2d998da788bca066ca5f148492b7085ee23372b12306
+      url: "https://pub.dev"
     source: hosted
     version: "1.3.1"
   checked_yaml:
     dependency: transitive
     description:
       name: checked_yaml
-      url: "https://pub.dartlang.org"
+      sha256: "3d1505d91afa809d177efd4eed5bb0eb65805097a1463abdd2add076effae311"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.0.2"
+  cli_completion:
+    dependency: transitive
+    description:
+      name: cli_completion
+      sha256: "6f0c5920a85878652a84ad48c722655a7ea7fe6cd7074452a7c1e3efa389307b"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   cli_util:
     dependency: transitive
     description:
       name: cli_util
-      url: "https://pub.dartlang.org"
+      sha256: "66f86e916d285c1a93d3b79587d94bd71984a66aac4ff74e524cfa7877f1395c"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.0"
+    version: "0.3.5"
   collection:
     dependency: transitive
     description:
       name: collection
-      url: "https://pub.dartlang.org"
+      sha256: "4a07be6cb69c84d677a6c3096fcf960cc3285a8330b4603e0d463d15d9bd934c"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.15.0"
+    version: "1.17.1"
   completion:
     dependency: "direct main"
     description:
       name: completion
-      url: "https://pub.dartlang.org"
+      sha256: f11b7a628e6c42b9edc9b0bc3aa490e2d930397546d2f794e8e1325909d11c60
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.1"
   convert:
     dependency: transitive
     description:
       name: convert
-      url: "https://pub.dartlang.org"
+      sha256: "0f08b14755d163f6e2134cb58222dd25ea2a2ee8a195e53983d57c075324d592"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.1.1"
   coverage:
     dependency: transitive
     description:
       name: coverage
-      url: "https://pub.dartlang.org"
+      sha256: "961c4aebd27917269b1896382c7cb1b1ba81629ba669ba09c27a7e5710ec9040"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.15.2"
+    version: "1.6.2"
   crypto:
     dependency: transitive
     description:
       name: crypto
-      url: "https://pub.dartlang.org"
+      sha256: aa274aa7774f8964e4f4f38cc994db7b6158dd36e9187aaceaddc994b35c6c67
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.1"
+    version: "3.0.2"
   csslib:
     dependency: transitive
     description:
       name: csslib
-      url: "https://pub.dartlang.org"
+      sha256: b36c7f7e24c0bdf1bf9a3da461c837d1de64b9f8beb190c9011d8c72a3dfd745
+      url: "https://pub.dev"
     source: hosted
-    version: "0.17.0"
+    version: "0.17.2"
   dartdoc:
     dependency: "direct dev"
     description:
       name: dartdoc
-      url: "https://pub.dartlang.org"
+      sha256: f9bf2fbf11e5dce3ffd085e1169f6218b632318403cb3f5762619e4d092e1e68
+      url: "https://pub.dev"
     source: hosted
-    version: "0.42.0"
+    version: "6.1.5"
   dartlin:
     dependency: "direct main"
     description:
       name: dartlin
-      url: "https://pub.dartlang.org"
+      sha256: "80764ff3d1801a086c2b802bd39ff6d306e783710741fab8e9981d2ba5ad68a1"
+      url: "https://pub.dev"
     source: hosted
     version: "0.6.3"
+  equatable:
+    dependency: transitive
+    description:
+      name: equatable
+      sha256: c2b87cb7756efdf69892005af546c56c0b5037f54d2a88269b4f347a505e3ca2
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.5"
   file:
     dependency: transitive
     description:
       name: file
-      url: "https://pub.dartlang.org"
+      sha256: "1b92bec4fc2a72f59a8e15af5f52cd441e4a7860b49499d69dfa817af20e925d"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.1"
+    version: "6.1.4"
   flame_lint:
     dependency: "direct dev"
     description:
       name: flame_lint
-      url: "https://pub.dartlang.org"
+      sha256: "537bca1509730377b048631f56b16749b011cb11468599de9f435f200806f61b"
+      url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
+  frontend_server_client:
+    dependency: transitive
+    description:
+      name: frontend_server_client
+      sha256: "408e3ca148b31c20282ad6f37ebfa6f4bdc8fede5b74bc2f08d9d92b55db3612"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.0"
   glob:
     dependency: transitive
     description:
       name: glob
-      url: "https://pub.dartlang.org"
+      sha256: "4515b5b6ddb505ebdd242a5f2cc5d22d3d6a80013789debfbda7777f47ea308c"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "2.1.1"
   html:
     dependency: transitive
     description:
       name: html
-      url: "https://pub.dartlang.org"
+      sha256: d9793e10dbe0e6c364f4c59bf3e01fb33a9b2a674bc7a1081693dba0614b6269
+      url: "https://pub.dev"
     source: hosted
-    version: "0.15.0"
+    version: "0.15.1"
   http:
     dependency: "direct main"
     description:
       name: http
-      url: "https://pub.dartlang.org"
+      sha256: "6aa2946395183537c8b880962d935877325d6a09a2867c3970c05c0fed6ac482"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.13.4"
+    version: "0.13.5"
   http_multi_server:
     dependency: transitive
     description:
       name: http_multi_server
-      url: "https://pub.dartlang.org"
+      sha256: "97486f20f9c2f7be8f514851703d0119c3596d14ea63227af6f7a481ef2b2f8b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.2.1"
   http_parser:
     dependency: transitive
     description:
       name: http_parser
-      url: "https://pub.dartlang.org"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.0.2"
   io:
     dependency: "direct main"
     description:
       name: io
-      url: "https://pub.dartlang.org"
+      sha256: "2ec25704aba361659e10e3e5f5d672068d332fc8ac516421d483a11e5cbd061e"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.3"
+    version: "1.0.4"
   js:
     dependency: transitive
     description:
       name: js
-      url: "https://pub.dartlang.org"
+      sha256: "323b7c70073cccf6b9b8d8b334be418a3293cfb612a560dc2737160a37bf61bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.6.3"
+    version: "0.6.6"
   json_annotation:
     dependency: transitive
     description:
       name: json_annotation
-      url: "https://pub.dartlang.org"
+      sha256: c33da08e136c3df0190bd5bbe51ae1df4a7d96e7954d1d7249fea2968a72d317
+      url: "https://pub.dev"
     source: hosted
-    version: "4.6.0"
+    version: "4.8.0"
   logging:
     dependency: transitive
     description:
       name: logging
-      url: "https://pub.dartlang.org"
+      sha256: "04094f2eb032cbb06c6f6e8d3607edcfcb0455e2bb6cbc010cb01171dcb64e6d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.1"
   markdown:
     dependency: transitive
     description:
       name: markdown
-      url: "https://pub.dartlang.org"
+      sha256: c2b81e184067b41d0264d514f7cdaa2c02d38511e39d6521a1ccc238f6d7b3f2
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "6.0.1"
   mason:
     dependency: "direct main"
     description:
       name: mason
-      url: "https://pub.dartlang.org"
+      sha256: e7b919e7d1f300504017d168d0d4d253cd06ef812149561d984abd3af8ad3ee2
+      url: "https://pub.dev"
     source: hosted
-    version: "0.1.0-dev.34"
+    version: "0.1.0-dev.41"
+  mason_api:
+    dependency: transitive
+    description:
+      name: mason_api
+      sha256: a4c9a742e605e1a80ace4aa77fb74fc49e126885aa935b22b75b65a47f6c8606
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-dev.9"
+  mason_cli:
+    dependency: "direct dev"
+    description:
+      name: mason_cli
+      sha256: "39a6315580398ff2ceb9cac2eca702905c22b1c143abecf8b08e7ef38178f25e"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.1.0-dev.44"
   mason_logger:
     dependency: transitive
     description:
       name: mason_logger
-      url: "https://pub.dartlang.org"
+      sha256: "893b47be5628aa97ec802111e64799b90bfeaf74f03976b0ca0fc19ecd0044c9"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.0"
+    version: "0.2.4"
   matcher:
     dependency: transitive
     description:
       name: matcher
-      url: "https://pub.dartlang.org"
+      sha256: c94db23593b89766cda57aab9ac311e3616cf87c6fa4e9749df032f66f30dcb8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.10"
+    version: "0.12.14"
   meta:
     dependency: transitive
     description:
       name: meta
-      url: "https://pub.dartlang.org"
+      sha256: "12307e7f0605ce3da64cf0db90e5fcab0869f3ca03f76be6bb2991ce0a55e82b"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.7.0"
+    version: "1.9.0"
   mime:
     dependency: transitive
     description:
       name: mime
-      url: "https://pub.dartlang.org"
+      sha256: e4ff8e8564c03f255408decd16e7899da1733852a9110a58fe6d1b817684a63e
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.4"
   mustache_template:
     dependency: transitive
     description:
       name: mustache_template
-      url: "https://pub.dartlang.org"
+      sha256: a46e26f91445bfb0b60519be280555b06792460b27b19e2b19ad5b9740df5d1c
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   node_preamble:
     dependency: transitive
     description:
       name: node_preamble
-      url: "https://pub.dartlang.org"
+      sha256: "8ebdbaa3b96d5285d068f80772390d27c21e1fa10fb2df6627b1b9415043608d"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.4.13"
+    version: "2.0.1"
   package_config:
     dependency: transitive
     description:
       name: package_config
-      url: "https://pub.dartlang.org"
+      sha256: "1c5b77ccc91e4823a5af61ee74e6b972db1ef98c2ff5a18d3161c982a55448bd"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   path:
     dependency: "direct main"
     description:
       name: path
-      url: "https://pub.dartlang.org"
+      sha256: "8829d8a55c13fc0e37127c29fedf290c102f4e40ae94ada574091fe0ff96c917"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.2"
+    version: "1.8.3"
   pedantic:
     dependency: "direct dev"
     description:
       name: pedantic
-      url: "https://pub.dartlang.org"
+      sha256: "67fc27ed9639506c856c840ccce7594d0bdcd91bc8d53d6e52359449a1d50602"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.11.0"
+    version: "1.11.1"
+  platform:
+    dependency: transitive
+    description:
+      name: platform
+      sha256: "4a451831508d7d6ca779f7ac6e212b4023dd5a7d08a27a63da33756410e32b76"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.0"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: db7306cf0249f838d1a24af52b5a5887c5bf7f31d8bb4e827d071dc0939ad346
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.6.2"
   pool:
     dependency: transitive
     description:
       name: pool
-      url: "https://pub.dartlang.org"
+      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      url: "https://pub.dev"
     source: hosted
     version: "1.5.1"
+  process:
+    dependency: transitive
+    description:
+      name: process
+      sha256: "53fd8db9cec1d37b0574e12f07520d582019cb6c44abf5479a01505099a34a09"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.2.4"
   process_run:
     dependency: "direct main"
     description:
       name: process_run
-      url: "https://pub.dartlang.org"
+      sha256: "1142d7f4f0c3f36393a1319406efcf481def2b6d862b2bf600c8ae8fa74d5bd8"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.12.3+2"
+    version: "0.12.5+2"
   prompts:
     dependency: "direct main"
     description:
       name: prompts
-      url: "https://pub.dartlang.org"
+      sha256: "3773b845e85a849f01e793c4fc18a45d52d7783b4cb6c0569fad19f9d0a774a1"
+      url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
   pub_semver:
     dependency: transitive
     description:
       name: pub_semver
-      url: "https://pub.dartlang.org"
+      sha256: "307de764d305289ff24ad257ad5c5793ce56d04947599ad68b3baa124105fc17"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.3"
+  pub_updater:
+    dependency: transitive
+    description:
+      name: pub_updater
+      sha256: "42890302ab2672adf567dc2b20e55b4ecc29d7e19c63b6b98143ab68dd717d3a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.4"
   recase:
     dependency: transitive
     description:
       name: recase
-      url: "https://pub.dartlang.org"
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
     source: hosted
-    version: "4.0.0"
+    version: "4.1.0"
   shelf:
     dependency: transitive
     description:
       name: shelf
-      url: "https://pub.dartlang.org"
+      sha256: c24a96135a2ccd62c64b69315a14adc5c3419df63b4d7c05832a346fdb73682c
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.4.0"
   shelf_packages_handler:
     dependency: transitive
     description:
       name: shelf_packages_handler
-      url: "https://pub.dartlang.org"
+      sha256: aef74dc9195746a384843102142ab65b6a4735bb3beea791e63527b88cc83306
+      url: "https://pub.dev"
     source: hosted
-    version: "2.0.1"
+    version: "3.0.1"
   shelf_static:
     dependency: transitive
     description:
       name: shelf_static
-      url: "https://pub.dartlang.org"
+      sha256: e792b76b96a36d4a41b819da593aff4bdd413576b3ba6150df5d8d9996d2e74c
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.9+2"
+    version: "1.1.1"
   shelf_web_socket:
     dependency: transitive
     description:
       name: shelf_web_socket
-      url: "https://pub.dartlang.org"
+      sha256: a988c0e8d8ffbdb8a28aa7ec8e449c260f3deb808781fe1284d22c5bba7156e8
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.4+1"
+    version: "1.0.3"
   source_map_stack_trace:
     dependency: transitive
     description:
       name: source_map_stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: "84cf769ad83aa6bb61e0aa5a18e53aea683395f196a6f39c4c881fb90ed4f7ae"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   source_maps:
     dependency: transitive
     description:
       name: source_maps
-      url: "https://pub.dartlang.org"
+      sha256: "490098075234dcedb83c5d949b4c93dad5e6b7702748de000be2b57b8e6b2427"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.10.10"
+    version: "0.10.11"
   source_span:
     dependency: transitive
     description:
       name: source_span
-      url: "https://pub.dartlang.org"
+      sha256: dd904f795d4b4f3b870833847c461801f6750a9fa8e61ea5ac53f9422b31f250
+      url: "https://pub.dev"
     source: hosted
-    version: "1.8.1"
+    version: "1.9.1"
   stack_trace:
     dependency: transitive
     description:
       name: stack_trace
-      url: "https://pub.dartlang.org"
+      sha256: c3c7d8edb15bee7f0f74debd4b9c5f3c2ea86766fe4178eb2a18eb30a0bdaed5
+      url: "https://pub.dev"
     source: hosted
-    version: "1.10.0"
+    version: "1.11.0"
   stream_channel:
     dependency: transitive
     description:
       name: stream_channel
-      url: "https://pub.dartlang.org"
+      sha256: "83615bee9045c1d322bbbd1ba209b7a749c2cbcdcb3fdd1df8eb488b3279c1c8"
+      url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   string_scanner:
     dependency: transitive
     description:
       name: string_scanner
-      url: "https://pub.dartlang.org"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.1.0"
+    version: "1.2.0"
   synchronized:
     dependency: transitive
     description:
       name: synchronized
-      url: "https://pub.dartlang.org"
+      sha256: "33b31b6beb98100bf9add464a36a8dd03eb10c7a8cf15aeec535e9b054aaf04b"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.0.0"
+    version: "3.0.1"
   term_glyph:
     dependency: transitive
     description:
       name: term_glyph
-      url: "https://pub.dartlang.org"
+      sha256: a29248a84fbb7c79282b40b8c72a1209db169a2e0542bce341da992fe1bc7e84
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "1.2.1"
   test:
     dependency: "direct dev"
     description:
       name: test
-      url: "https://pub.dartlang.org"
+      sha256: b54d427664c00f2013ffb87797a698883c46aee9288e027a50b46eaee7486fa2
+      url: "https://pub.dev"
     source: hosted
-    version: "1.16.5"
+    version: "1.22.2"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      url: "https://pub.dartlang.org"
+      sha256: "6182294da5abf431177fccc1ee02401f6df30f766bc6130a0852c6b6d7ee6b2d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.2.19"
+    version: "0.4.18"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      url: "https://pub.dartlang.org"
+      sha256: "95ecc12692d0dd59080ab2d38d9cf32c7e9844caba23ff6cd285690398ee8ef4"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.3.15"
+    version: "0.4.22"
   typed_data:
     dependency: transitive
     description:
       name: typed_data
-      url: "https://pub.dartlang.org"
+      sha256: "26f87ade979c47a150c9eaab93ccd2bebe70a27dc0b4b29517f2904f04eb11a5"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.3.0"
+    version: "1.3.1"
   vm_service:
     dependency: transitive
     description:
       name: vm_service
-      url: "https://pub.dartlang.org"
+      sha256: "2277c73618916ae3c2082b6df67b6ebb64b4c69d9bf23b23700707952ac30e60"
+      url: "https://pub.dev"
     source: hosted
-    version: "6.1.0+1"
+    version: "10.1.2"
   watcher:
     dependency: transitive
     description:
       name: watcher
-      url: "https://pub.dartlang.org"
+      sha256: "6a7f46926b01ce81bfc339da6a7f20afbe7733eff9846f6d6a5466aa4c6667c0"
+      url: "https://pub.dev"
     source: hosted
-    version: "1.0.0"
+    version: "1.0.2"
   web_socket_channel:
     dependency: transitive
     description:
       name: web_socket_channel
-      url: "https://pub.dartlang.org"
+      sha256: ca49c0bc209c687b887f30527fb6a9d80040b072cc2990f34b9bec3e7663101b
+      url: "https://pub.dev"
     source: hosted
-    version: "1.2.0"
+    version: "2.3.0"
   webkit_inspection_protocol:
     dependency: transitive
     description:
       name: webkit_inspection_protocol
-      url: "https://pub.dartlang.org"
+      sha256: "67d3a8b6c79e1987d19d848b0892e582dbb0c66c57cc1fef58a177dd2aa2823d"
+      url: "https://pub.dev"
     source: hosted
-    version: "0.7.5"
+    version: "1.2.0"
   yaml:
     dependency: "direct main"
     description:
       name: yaml
-      url: "https://pub.dartlang.org"
+      sha256: "23812a9b125b48d4007117254bca50abb6c712352927eece9e155207b1db2370"
+      url: "https://pub.dev"
     source: hosted
-    version: "3.1.0"
+    version: "3.1.1"
 sdks:
-  dart: ">=2.17.0 <3.0.0"
+  dart: ">=2.19.0-345.0.dev <4.0.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -25,6 +25,6 @@ dependencies:
 
 dev_dependencies:
   dartdoc: ^0.42.0
-  flame_lint: ^0.1.1
+  flame_lint: ^0.2.0
   pedantic: ^1.11.0
   test: ^1.16.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,14 +17,15 @@ dependencies:
   dartlin: ^0.6.3
   http: ^0.13.4
   io: ^1.0.3
-  mason: ^0.1.0-dev.34
+  mason: ^0.1.0-dev.41
   path: ^1.8.2
   process_run: ^0.12.3+2
   prompts: ^2.0.0
   yaml: ^3.1.0
 
 dev_dependencies:
-  dartdoc: ^0.42.0
+  dartdoc: ^6.1.5
   flame_lint: ^0.2.0
+  mason_cli: ^0.1.0-dev.44
   pedantic: ^1.11.0
   test: ^1.16.0

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,7 +1,11 @@
 #!/bin/bash -xe
 
-rm -rf lib/templates/bricks
 # TODO(luan): use a wildcard once supported
-mason bundle bricks/simple -t dart -o lib/templates/bricks/
-mason bundle bricks/basics -t dart -o lib/templates/bricks/
-mason bundle bricks/example -t dart -o lib/templates/bricks/
+function bundle {
+    flutter pub run mason_cli:mason bundle $1 -t dart -o lib/templates/bricks/
+}
+
+rm -rf lib/templates/bricks
+bundle bricks/simple
+bundle bricks/basics
+bundle bricks/example


### PR DESCRIPTION
* Update flame_lint to 0.2.0 (to fix deprecated option warning + more rules)
* Bump other packages (mason, dartdoc)
* Update build script to use mason from pubspec instead of requiring global mason_cli
* Use newer mason to re-generate the binary files (should be no-op, just different format)
* Support old versions of flame implicitly (before you HAD to pick last 3, now we show last 5 but you can pick any)