### PR TITLE
fix: Hardcode version instead of trying to find the pubpsec.yaml

### DIFF
--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -1,20 +1,11 @@
-import 'dart:io';
-
-import 'package:ignite_cli/utils.dart';
+import 'package:ignite_cli/version.g.dart';
 import 'package:process_run/process_run.dart';
-import 'package:yaml/yaml.dart';
 
 Future<void> versionCommand() async {
   print(r'$ ignite --version:');
-  print(await getVersionFromPubspec());
+  print(igniteVersion);
   print('');
   await runExecutableArguments('dart', ['--version'], verbose: true);
   print('');
   await runExecutableArguments('flutter', ['--version'], verbose: true);
-}
-
-Future<String> getVersionFromPubspec() async {
-  final f = File(getBundledFile('pubspec.yaml'));
-  final yaml = loadYaml(await f.readAsString()) as Map;
-  return yaml['version'] as String;
 }

--- a/lib/version.g.dart
+++ b/lib/version.g.dart
@@ -1,0 +1,3 @@
+// This file is generated. Do not manually edit.
+String igniteVersion = '0.6.0';
+

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -1,5 +1,7 @@
 #!/bin/bash -xe
 
+./scripts/generate-version.sh
+
 # TODO(luan): use a wildcard once supported
 function bundle {
     dart run mason_cli:mason bundle $1 -t dart -o lib/templates/bricks/

--- a/scripts/generate-version.sh
+++ b/scripts/generate-version.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+version=`cat pubspec.yaml | grep 'version: ' | cut -d ' ' -f 2`
+contents="// This file is generated. Do not manually edit.\nString igniteVersion = '$version';\n"
+echo "$contents" | sed 's/\\n/\n/g' > lib/version.g.dart

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -1,0 +1,5 @@
+#!/bin/bash -xe
+
+./scripts/build.sh
+./scripts/analyze.sh
+(cd test ; ./run.sh)


### PR DESCRIPTION
Kinda gave up on https://github.com/flame-engine/ignite-cli/issues/8 - apparently there is no easy way to get metadata about the global binaries.

This just replaces it with what melos does: https://github.com/invertase/melos/blob/main/packages/melos/lib/version.g.dart