### PR TITLE
fix: Prevent a project being named test

### DIFF
--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -24,6 +24,7 @@ Future<void> createCommand(ArgResults command) async {
     'Choose a name for your project: ',
     desc: 'Note: this must be a valid dart identifier (no dashes). '
         'For example: my_game',
+    validate: (it) => !it.contains('-') && it != 'test',
   );
 
   final org = getString(
@@ -34,6 +35,7 @@ Future<void> createCommand(ArgResults command) async {
     desc: 'Note: this is a dot separated list of "packages", '
         'normally in reverse domain notation. '
         'For example: org.flame_engine.games',
+    validate: (it) => !it.contains('-'),
   );
 
   final versions = FlameVersionManager.singleton.versions;

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -17,6 +17,7 @@ String getString(
   String message, {
   required bool isInteractive,
   String? desc,
+  bool Function(String)? validate,
 }) {
   var value = results[name] as String?;
   if (!isInteractive) {
@@ -29,7 +30,7 @@ String getString(
     if (desc != null) {
       stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
-    value = prompts.get(message, validate: (it) => !it.contains('-'));
+    value = prompts.get(message, validate: validate);
     if (desc != null) {
       stdout.write('\r\u{1B}[K');
     }


### PR DESCRIPTION
Turns out if you make a package name `test` it conflicts with Dart's `test` package.
Also the utils `getString` should have hardcoded validations that are not generic for all Strings.
So this PR fixes both things.