### PR TITLE
feat: Integrate mason_logger for improved logging and user prompts

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,7 +2,7 @@ include: package:flame_lint/analysis_options.yaml
 
 linter:
   rules:
-    avoid_print: false # since it is a CLI application
+    avoid_print: true # should always use a Logger
 
 analyzer:
   exclude:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -2,4 +2,4 @@ include: package:flame_lint/analysis_options.yaml
 
 analyzer:
   exclude:
-    - bricks/
+    - bricks/**/*

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,9 +1,5 @@
 include: package:flame_lint/analysis_options.yaml
 
-linter:
-  rules:
-    avoid_print: true # should always use a Logger
-
 analyzer:
   exclude:
     - bricks/

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -1,14 +1,33 @@
 import 'dart:io';
 
+import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
-import 'package:ignite_cli/ignite_commmand_runner.dart';
+import 'package:ignite_cli/ignite_command_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 Future<void> main(List<String> args) async {
   final runner = IgniteCommandRunner(
-    logger: Logger(),
-    flameVersionManager: await FlameVersionManager.fetch(),
+    IgniteContext(
+      logger: Logger(),
+      flameVersionManager: await FlameVersionManager.fetch(),
+      process: _IgniteProcess(),
+    ),
   );
 
-  exit((await runner.run(args)).code);
+  exit(await runner.run(args));
+}
+
+class _IgniteProcess extends IgniteProcess {
+  @override
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+  }) {
+    return Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+    );
+  }
 }

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -1,7 +1,7 @@
 import 'dart:io';
 
 import 'package:ignite_cli/flame_version_manager.dart';
-import 'package:ignite_cli/main.dart';
+import 'package:ignite_cli/ignite_commmand_runner.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 Future<void> main(List<String> args) async {

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -7,7 +7,7 @@ import 'package:mason_logger/mason_logger.dart';
 Future<void> main(List<String> args) async {
   final runner = IgniteCommandRunner(
     logger: Logger(),
-    flameVersionManager: await FlameVersionManager.init(),
+    flameVersionManager: await FlameVersionManager.fetch(),
   );
 
   exit((await runner.run(args)).code);

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -1,5 +1,14 @@
-import 'package:ignite_cli/main.dart';
+import 'dart:io';
 
-void main(List<String> args) {
-  mainCommand(args);
+import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:ignite_cli/main.dart';
+import 'package:mason_logger/mason_logger.dart';
+
+Future<void> main(List<String> args) async {
+  final runner = IgniteCommandRunner(
+    logger: Logger(),
+    flameVersionManager: await FlameVersionManager.init(),
+  );
+
+  exit((await runner.run(args)).code);
 }

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:ignite_cli/ignite_command_runner.dart';
+import 'package:ignite_cli/ignite_context.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 Future<void> main(List<String> args) async {

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -6,12 +6,11 @@ import 'package:ignite_cli/ignite_context.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 Future<void> main(List<String> args) async {
-  final runner = IgniteCommandRunner(
-    IgniteContext(
-      logger: Logger(),
-      flameVersionManager: await FlameVersionManager.fetch(),
-    ),
-  );
+  final manager = await FlameVersionManager.fetch();
+  final context = IgniteContext(logger: Logger(), flameVersionManager: manager);
+  final runner = IgniteCommandRunner(context);
+  final code = await runner.run(args);
 
-  exit(await runner.run(args));
+  // ensure all buffered output is written before exit
+  await Future.wait([stdout.close(), stderr.close()]).then((_) => exit(code));
 }

--- a/bin/ignite.dart
+++ b/bin/ignite.dart
@@ -10,24 +10,8 @@ Future<void> main(List<String> args) async {
     IgniteContext(
       logger: Logger(),
       flameVersionManager: await FlameVersionManager.fetch(),
-      process: _IgniteProcess(),
     ),
   );
 
   exit(await runner.run(args));
-}
-
-class _IgniteProcess extends IgniteProcess {
-  @override
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    String? workingDirectory,
-  }) {
-    return Process.run(
-      executable,
-      arguments,
-      workingDirectory: workingDirectory,
-    );
-  }
 }

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:args/command_runner.dart';
 import 'package:dartlin/dartlin.dart';
 import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
@@ -10,16 +9,9 @@ import 'package:ignite_cli/utils.dart';
 import 'package:mason/mason.dart';
 import 'package:process_run/process_run.dart';
 
-class SubCommand extends Command<ExitCode> {
+class CreateCommand extends IgniteCommand {
   @override
-  String get description => throw UnimplementedError();
-
-  @override
-  String get name => throw UnimplementedError();
-}
-
-class CreateCommand extends Command<ExitCode> with IgniteCommand {
-  CreateCommand() {
+  void setup(ArgParser argParser) {
     final packages = context.flameVersionManager.versions;
     final flameVersions = packages[Package.flame]!;
 

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -6,7 +6,8 @@ import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:ignite_cli/templates/template.dart';
 import 'package:ignite_cli/utils.dart';
-import 'package:mason/mason.dart';
+import 'package:mason/mason.dart'
+    show DirectoryGeneratorTarget, ExitCode, MasonGenerator, red;
 
 class CreateCommand extends IgniteCommand {
   CreateCommand(super.context) {
@@ -188,14 +189,14 @@ Future<int> createCommand(
   try {
     if (createFolder) {
       progress.update('Running [mkdir] on $actualDir');
-      processResult = await context.process.run('mkdir', [actualDir]);
+      processResult = await context.run('mkdir', [actualDir]);
       if (processResult.exitCode > ExitCode.success.code) {
         return code = processResult.exitCode;
       }
     }
 
     progress.update('Running [flutter create] on $actualDir');
-    processResult = await context.process.run(
+    processResult = await context.run(
       'flutter',
       'create --org $org --project-name $name .'.split(' '),
       workingDirectory: actualDir,
@@ -205,7 +206,7 @@ Future<int> createCommand(
     }
 
     progress.update('Running [rm -rf lib test] on $actualDir');
-    processResult = await context.process.run(
+    processResult = await context.run(
       'rm',
       '-rf lib test'.split(' '),
       workingDirectory: actualDir,
@@ -237,7 +238,7 @@ Future<int> createCommand(
 
     if (!canHaveTests) {
       progress.update('Removing tests');
-      processResult = await context.process.run(
+      processResult = await context.run(
         'rm',
         '-rf test'.split(' '),
         workingDirectory: actualDir,
@@ -248,7 +249,7 @@ Future<int> createCommand(
     }
 
     progress.update('Removing tests');
-    processResult = await context.process.run(
+    processResult = await context.run(
       'flutter',
       'pub get'.split(' '),
       workingDirectory: actualDir,

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -183,14 +183,14 @@ Future<int> createCommand(
 
   final progress = context.logger.progress('Generating project');
   ProcessResult? processResult;
-  var exitCode = ExitCode.success.code;
+  var code = ExitCode.success.code;
 
   try {
     if (createFolder) {
       progress.update('Running [mkdir] on $actualDir');
       processResult = await context.process.run('mkdir', [actualDir]);
       if (processResult.exitCode > ExitCode.success.code) {
-        return exitCode = processResult.exitCode;
+        return code = processResult.exitCode;
       }
     }
 
@@ -201,7 +201,7 @@ Future<int> createCommand(
       workingDirectory: actualDir,
     );
     if (processResult.exitCode > ExitCode.success.code) {
-      return exitCode = processResult.exitCode;
+      return code = processResult.exitCode;
     }
 
     progress.update('Running [rm -rf lib test] on $actualDir');
@@ -211,7 +211,7 @@ Future<int> createCommand(
       workingDirectory: actualDir,
     );
     if (processResult.exitCode > ExitCode.success.code) {
-      return exitCode = processResult.exitCode;
+      return code = processResult.exitCode;
     }
     progress.update('Bundling game template');
 
@@ -243,7 +243,7 @@ Future<int> createCommand(
         workingDirectory: actualDir,
       );
       if (processResult.exitCode > ExitCode.success.code) {
-        return exitCode = processResult.exitCode;
+        return code = processResult.exitCode;
       }
     }
 
@@ -255,18 +255,18 @@ Future<int> createCommand(
     );
 
     if (processResult.exitCode > ExitCode.success.code) {
-      return exitCode = processResult.exitCode;
+      return code = processResult.exitCode;
     }
 
     progress
       ..complete('Updated ${files.length} files on top of flutter create.')
       ..complete('Your new Flame project was successfully created!');
 
-    return exitCode;
+    return code;
   } catch (_) {
     if (processResult != null) {
       progress.fail(processResult.stderr.toString());
-      exitCode = processResult.exitCode;
+      code = processResult.exitCode;
     } else {
       progress.fail();
     }

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -121,16 +121,16 @@ Future<int> createCommand(
   );
 
   final versions = context.flameVersionManager.versions;
-  final flameVersions = versions[Package.flame];
+  final flameVersions = versions[Package.flame]!;
   final flameVersion = getOption(
     logger: context.logger,
     isInteractive: interactive,
     command,
     'flame-version',
     'Which Flame version do you wish to use?',
-    (flameVersions?.visible ?? []).associateWith((e) => e),
-    defaultsTo: flameVersions?.versions.first,
-    fullOptions: flameVersions?.versions.associateWith((e) => e) ?? {},
+    flameVersions.visible.associateWith((e) => e),
+    defaultsTo: flameVersions.versions.first,
+    fullOptions: flameVersions.versions.associateWith((e) => e),
   );
 
   final extraPackageOptions = context.flameVersionManager.versions.keys

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -11,6 +11,7 @@ import 'package:process_run/process_run.dart';
 
 Future<void> createCommand(ArgResults command) async {
   final interactive = command['interactive'] != 'false';
+  final logger = Logger();
 
   if (interactive) {
     stdout.write('\nWelcome to ${ansi.red.wrap('Ignite CLI')}! 🔥\n');
@@ -19,6 +20,7 @@ Future<void> createCommand(ArgResults command) async {
 
   final name = getString(
     isInteractive: interactive,
+    logger: logger,
     command,
     'name',
     'Choose a name for your project: ',
@@ -34,6 +36,7 @@ Future<void> createCommand(ArgResults command) async {
   );
 
   final org = getString(
+    logger: logger,
     isInteractive: interactive,
     command,
     'org',
@@ -51,6 +54,7 @@ Future<void> createCommand(ArgResults command) async {
   final versions = FlameVersionManager.singleton.versions;
   final flameVersions = versions[Package.flame]!;
   final flameVersion = getOption(
+    logger: logger,
     isInteractive: interactive,
     command,
     'flame-version',
@@ -65,6 +69,7 @@ Future<void> createCommand(ArgResults command) async {
       .map((key) => key.name)
       .toList();
   final extraPackages = getMultiOption(
+    logger: logger,
     isInteractive: interactive,
     isRequired: false,
     command,
@@ -86,6 +91,7 @@ Future<void> createCommand(ArgResults command) async {
   print('\nYour current directory is: $currentDir');
 
   final createFolder = getOption(
+        logger: logger,
         isInteractive: interactive,
         command,
         'create-folder',
@@ -100,6 +106,7 @@ Future<void> createCommand(ArgResults command) async {
 
   print('\n');
   final template = getOption(
+    logger: logger,
     isInteractive: interactive,
     command,
     'template',

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -7,7 +7,7 @@ import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:ignite_cli/ignite_context.dart';
 import 'package:ignite_cli/templates/template.dart';
 import 'package:ignite_cli/utils.dart';
-import 'package:mason/mason.dart' show ExitCode, red;
+import 'package:mason/mason.dart';
 
 class CreateCommand extends IgniteCommand {
   CreateCommand(super.context) {

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -10,7 +10,15 @@ import 'package:ignite_cli/utils.dart';
 import 'package:mason/mason.dart';
 import 'package:process_run/process_run.dart';
 
-class CreateCommand extends Command<ExitCode> with ContextProvider {
+class SubCommand extends Command<ExitCode> {
+  @override
+  String get description => throw UnimplementedError();
+
+  @override
+  String get name => throw UnimplementedError();
+}
+
+class CreateCommand extends Command<ExitCode> with IgniteCommand {
   CreateCommand() {
     final packages = context.flameVersionManager.versions;
     final flameVersions = packages[Package.flame]!;

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -114,7 +114,7 @@ Future<void> createCommand(
     isInteractive: interactive,
     command,
     'org',
-    'Choose an org for your project: ',
+    'Choose an org for your project:',
     desc: 'Note: this is a dot separated list of "packages", '
         'normally in reverse domain notation. '
         'For example: org.flame_engine.games',
@@ -245,6 +245,6 @@ Future<void> createCommand(
     verbose: logger.level == Level.verbose,
   );
 
-  // logger.info('Updated ${files.length} files on top of flutter create.\n');
+  logger.info('Updated ${files.length} files on top of flutter create.\n');
   logger.info('Your new Flame project was successfully created!');
 }

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -4,10 +4,10 @@ import 'package:args/args.dart';
 import 'package:dartlin/dartlin.dart';
 import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:ignite_cli/ignite_context.dart';
 import 'package:ignite_cli/templates/template.dart';
 import 'package:ignite_cli/utils.dart';
-import 'package:mason/mason.dart'
-    show DirectoryGeneratorTarget, ExitCode, MasonGenerator, red;
+import 'package:mason/mason.dart' show ExitCode, red;
 
 class CreateCommand extends IgniteCommand {
   CreateCommand(super.context) {
@@ -217,8 +217,8 @@ Future<int> createCommand(
     progress.update('Bundling game template');
 
     final bundle = Template.byKey(template).bundle;
-    final generator = await MasonGenerator.fromBundle(bundle);
-    final target = DirectoryGeneratorTarget(Directory(actualDir));
+    final generator = await context.generatorFromBundle(bundle);
+    final target = context.createTarget(Directory(actualDir));
 
     final variables = <String, dynamic>{
       'name': name,
@@ -233,6 +233,7 @@ Future<int> createCommand(
           .map((package) => package.toMustache(versions, flameVersion))
           .toList(),
     };
+
     final files = await generator.generate(target, vars: variables);
     final canHaveTests = devDependencies.contains(Package.flameTest);
 

--- a/lib/commands/create_command.dart
+++ b/lib/commands/create_command.dart
@@ -9,9 +9,8 @@ import 'package:io/ansi.dart' as ansi;
 import 'package:mason/mason.dart';
 import 'package:process_run/process_run.dart';
 
-Future<void> createCommand(ArgResults command) async {
+Future<void> createCommand(ArgResults command, Logger logger) async {
   final interactive = command['interactive'] != 'false';
-  final logger = Logger();
 
   if (interactive) {
     stdout.write('\nWelcome to ${ansi.red.wrap('Ignite CLI')}! 🔥\n');

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,5 +1,5 @@
 import 'dart:async';
-import 'dart:io' show ProcessResult;
+import 'dart:io' show Process, ProcessResult;
 
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
@@ -19,18 +19,20 @@ class IgniteContext {
   const IgniteContext({
     required this.logger,
     required this.flameVersionManager,
-    required this.process,
   });
 
   final Logger logger;
   final FlameVersionManager flameVersionManager;
-  final IgniteProcess process;
-}
 
-abstract class IgniteProcess {
   Future<ProcessResult> run(
     String executable,
     List<String> arguments, {
     String? workingDirectory,
-  });
+  }) {
+    return Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+    );
+  }
 }

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,29 +1,37 @@
+import 'dart:async';
+
+import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
-import 'package:ignite_cli/main.dart';
 import 'package:mason/mason.dart';
 import 'package:mason_logger/mason_logger.dart';
 
-mixin IgniteCommand<T> on Command<T> {
-  /// Forces sun-commands added to [IgniteCommand] command
-  /// to use the [IgniteCommand] mixin on those sun-commands.
+abstract class IgniteCommand extends Command<ExitCode> {
+  late IgniteContext context;
+
+  void setup(ArgParser argParser);
+
   @override
-  void addSubcommand(covariant IgniteCommand<T> command) {
+  void addSubcommand(Command<ExitCode> command) {
+    if (command is IgniteCommand) {
+      command
+        ..context = context
+        ..setup(command.argParser);
+    }
+
     super.addSubcommand(command);
   }
 
-  IgniteContext get context {
-    if (runner case IgniteCommandRunner(:final IgniteContext context)) {
-      return context;
-    }
-    // definitely in some invalid state
-    throw StateError('The current runner must be a [IgniteCommandRunner]');
-  }
+  @override
+  Future<ExitCode> run();
 }
 
 class IgniteContext {
+  const IgniteContext({
+    required this.logger,
+    required this.flameVersionManager,
+  });
+
   final Logger logger;
   final FlameVersionManager flameVersionManager;
-
-  IgniteContext({required this.logger, required this.flameVersionManager});
 }

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,0 +1,20 @@
+import 'package:args/command_runner.dart';
+import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:ignite_cli/main.dart';
+import 'package:mason_logger/mason_logger.dart';
+
+mixin ContextProvider<T> on Command<T> {
+  IgniteContext get context {
+    if (runner case IgniteCommandRunner(:final IgniteContext context)) {
+      return context;
+    }
+    throw Exception('The current runner must be a [IgniteCommandRunner]');
+  }
+}
+
+class IgniteContext {
+  final Logger logger;
+  final FlameVersionManager flameVersionManager;
+
+  IgniteContext({required this.logger, required this.flameVersionManager});
+}

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,26 +1,14 @@
 import 'dart:async';
 
-import 'package:args/args.dart';
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:mason/mason.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 abstract class IgniteCommand extends Command<ExitCode> {
-  late IgniteContext context;
+  final IgniteContext context;
 
-  void setup(ArgParser argParser);
-
-  @override
-  void addSubcommand(Command<ExitCode> command) {
-    if (command is IgniteCommand) {
-      command
-        ..context = context
-        ..setup(command.argParser);
-    }
-
-    super.addSubcommand(command);
-  }
+  IgniteCommand(this.context);
 
   @override
   Future<ExitCode> run();

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,25 +1,36 @@
 import 'dart:async';
+import 'dart:io' show ProcessResult;
 
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:mason/mason.dart';
 import 'package:mason_logger/mason_logger.dart';
 
-abstract class IgniteCommand extends Command<ExitCode> {
+abstract class IgniteCommand extends Command<int> {
   final IgniteContext context;
 
   IgniteCommand(this.context);
 
   @override
-  Future<ExitCode> run();
+  Future<int> run();
 }
 
 class IgniteContext {
   const IgniteContext({
     required this.logger,
     required this.flameVersionManager,
+    required this.process,
   });
 
   final Logger logger;
   final FlameVersionManager flameVersionManager;
+  final IgniteProcess process;
+}
+
+abstract class IgniteProcess {
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+  });
 }

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,10 +1,7 @@
 import 'dart:async';
-import 'dart:io' show Process, ProcessResult;
 
 import 'package:args/command_runner.dart';
-import 'package:ignite_cli/flame_version_manager.dart';
-import 'package:mason/mason.dart';
-import 'package:mason_logger/mason_logger.dart';
+import 'package:ignite_cli/ignite_context.dart';
 
 abstract class IgniteCommand extends Command<int> {
   final IgniteContext context;
@@ -13,26 +10,4 @@ abstract class IgniteCommand extends Command<int> {
 
   @override
   Future<int> run();
-}
-
-class IgniteContext {
-  const IgniteContext({
-    required this.logger,
-    required this.flameVersionManager,
-  });
-
-  final Logger logger;
-  final FlameVersionManager flameVersionManager;
-
-  Future<ProcessResult> run(
-    String executable,
-    List<String> arguments, {
-    String? workingDirectory,
-  }) {
-    return Process.run(
-      executable,
-      arguments,
-      workingDirectory: workingDirectory,
-    );
-  }
 }

--- a/lib/commands/ignite_command.dart
+++ b/lib/commands/ignite_command.dart
@@ -1,14 +1,23 @@
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:ignite_cli/main.dart';
+import 'package:mason/mason.dart';
 import 'package:mason_logger/mason_logger.dart';
 
-mixin ContextProvider<T> on Command<T> {
+mixin IgniteCommand<T> on Command<T> {
+  /// Forces sun-commands added to [IgniteCommand] command
+  /// to use the [IgniteCommand] mixin on those sun-commands.
+  @override
+  void addSubcommand(covariant IgniteCommand<T> command) {
+    super.addSubcommand(command);
+  }
+
   IgniteContext get context {
     if (runner case IgniteCommandRunner(:final IgniteContext context)) {
       return context;
     }
-    throw Exception('The current runner must be a [IgniteCommandRunner]');
+    // definitely in some invalid state
+    throw StateError('The current runner must be a [IgniteCommandRunner]');
   }
 }
 

--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -1,32 +1,31 @@
+import 'dart:math';
+
+import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/version.g.dart';
-import 'package:mason/mason.dart';
-import 'package:process_run/process_run.dart';
 
-Future<void> versionCommand(Logger logger) async {
-  logger.info('ignite --version: $igniteVersion\n');
+Future<int> versionCommand(IgniteContext context) async {
+  context.logger.info('ignite --version: $igniteVersion\n');
 
-  final [dartProcess, flutterProcess] = await [
-    runExecutableArguments(
-      'dart',
-      ['--version'],
-      commandVerbose: false,
-      verbose: false,
-    ),
-    runExecutableArguments(
-      'flutter',
-      ['--version'],
-      commandVerbose: false,
-      verbose: false,
-    ),
-  ].wait;
+  final (dartProcess, flutterProcess) = await (
+    context.process.run('dart', ['--version']),
+    context.process.run('flutter', ['--version']),
+  ).wait;
 
-  logger.info('${dartProcess.stdout}');
-  logger.info('${flutterProcess.stdout}');
+  if (dartProcess.stdout case final String out) {
+    context.logger.info(out);
+  }
+
+  if (flutterProcess.stdout case final String out) {
+    context.logger.info(out);
+  }
 
   if (dartProcess.stderr case final String err when err.isNotEmpty) {
-    logger.err(err);
+    context.logger.err(err);
   }
+
   if (flutterProcess.stderr case final String err when err.isNotEmpty) {
-    logger.err(err);
+    context.logger.err(err);
   }
+
+  return max<int>(dartProcess.exitCode, flutterProcess.exitCode);
 }

--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -3,10 +3,30 @@ import 'package:mason/mason.dart';
 import 'package:process_run/process_run.dart';
 
 Future<void> versionCommand(Logger logger) async {
-  logger.detail(r'$ ignite --version:');
-  logger.detail(igniteVersion);
-  logger.detail('');
-  await runExecutableArguments('dart', ['--version'], verbose: true);
-  logger.detail('');
-  await runExecutableArguments('flutter', ['--version'], verbose: true);
+  logger.info('ignite --version: $igniteVersion\n');
+
+  final [dartProcess, flutterProcess] = await [
+    runExecutableArguments(
+      'dart',
+      ['--version'],
+      commandVerbose: false,
+      verbose: false,
+    ),
+    runExecutableArguments(
+      'flutter',
+      ['--version'],
+      commandVerbose: false,
+      verbose: false,
+    ),
+  ].wait;
+
+  logger.info('${dartProcess.stdout}');
+  logger.info('${flutterProcess.stdout}');
+
+  if (dartProcess.stderr case final String err when err.isNotEmpty) {
+    logger.err(err);
+  }
+  if (flutterProcess.stderr case final String err when err.isNotEmpty) {
+    logger.err(err);
+  }
 }

--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -7,8 +7,8 @@ Future<int> versionCommand(IgniteContext context) async {
   context.logger.info('ignite --version: $igniteVersion\n');
 
   final (dartProcess, flutterProcess) = await (
-    context.process.run('dart', ['--version']),
-    context.process.run('flutter', ['--version']),
+    context.run('dart', ['--version']),
+    context.run('flutter', ['--version']),
   ).wait;
 
   if (dartProcess.stdout case final String out) {

--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -1,11 +1,12 @@
 import 'package:ignite_cli/version.g.dart';
+import 'package:mason/mason.dart';
 import 'package:process_run/process_run.dart';
 
-Future<void> versionCommand() async {
-  print(r'$ ignite --version:');
-  print(igniteVersion);
-  print('');
+Future<void> versionCommand(Logger logger) async {
+  logger.detail(r'$ ignite --version:');
+  logger.detail(igniteVersion);
+  logger.detail('');
   await runExecutableArguments('dart', ['--version'], verbose: true);
-  print('');
+  logger.detail('');
   await runExecutableArguments('flutter', ['--version'], verbose: true);
 }

--- a/lib/commands/version_command.dart
+++ b/lib/commands/version_command.dart
@@ -1,6 +1,6 @@
 import 'dart:math';
 
-import 'package:ignite_cli/commands/ignite_command.dart';
+import 'package:ignite_cli/ignite_context.dart';
 import 'package:ignite_cli/version.g.dart';
 
 Future<int> versionCommand(IgniteContext context) async {

--- a/lib/flame_version_manager.dart
+++ b/lib/flame_version_manager.dart
@@ -3,11 +3,7 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class FlameVersionManager {
-  static late FlameVersionManager singleton;
-
-  static Future<void> init() async {
-    singleton = await FlameVersionManager.fetch();
-  }
+  static Future<FlameVersionManager> init() => FlameVersionManager.fetch();
 
   final Map<Package, Versions> versions;
 

--- a/lib/flame_version_manager.dart
+++ b/lib/flame_version_manager.dart
@@ -3,8 +3,6 @@ import 'dart:convert';
 import 'package:http/http.dart' as http;
 
 class FlameVersionManager {
-  static Future<FlameVersionManager> init() => FlameVersionManager.fetch();
-
   final Map<Package, Versions> versions;
 
   const FlameVersionManager._(this.versions);

--- a/lib/ignite_command_runner.dart
+++ b/lib/ignite_command_runner.dart
@@ -3,8 +3,8 @@ import 'dart:io';
 
 import 'package:args/command_runner.dart';
 import 'package:ignite_cli/commands/create_command.dart';
-import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/commands/version_command.dart';
+import 'package:ignite_cli/ignite_context.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 class IgniteCommandRunner extends CommandRunner<int> {

--- a/lib/ignite_commmand_runner.dart
+++ b/lib/ignite_commmand_runner.dart
@@ -69,6 +69,6 @@ class IgniteCommandRunner extends CommandRunner<ExitCode> {
     }
   }
 
-  static const _description = 'Ignite your projects with flame; '
+  static const _description = 'Ignite your projects with Flame; '
       'a CLI scaffolding tool to create and setup your Flame projects.';
 }

--- a/lib/ignite_commmand_runner.dart
+++ b/lib/ignite_commmand_runner.dart
@@ -9,18 +9,22 @@ import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:mason_logger/mason_logger.dart';
 
 class IgniteCommandRunner extends CommandRunner<ExitCode> {
-  late final IgniteContext context;
+  late IgniteContext context;
 
   IgniteCommandRunner({
     required Logger logger,
     required FlameVersionManager flameVersionManager,
-  }) : super(_name, _description) {
+  }) : super('ignite', _description) {
     context = IgniteContext(
       logger: logger,
       flameVersionManager: flameVersionManager,
     );
 
-    addCommand(CreateCommand());
+    addCommand(CreateCommand(context));
+
+    argParser.addFlag(
+      'verbose',
+    );
 
     argParser.addFlag(
       'version',
@@ -30,17 +34,13 @@ class IgniteCommandRunner extends CommandRunner<ExitCode> {
   }
 
   @override
-  void addCommand(Command<ExitCode> command) {
-    if (command is IgniteCommand) {
-      command.context = context;
-    }
-    super.addCommand(command);
-  }
-
-  @override
   Future<ExitCode> run(Iterable<String> args) async {
     try {
       final parsedArgs = parse(args);
+
+      if (parsedArgs['verbose'] == true) {
+        context.logger.level = Level.verbose;
+      }
 
       if (parsedArgs['version'] == true) {
         await versionCommand(context.logger);
@@ -69,7 +69,6 @@ class IgniteCommandRunner extends CommandRunner<ExitCode> {
     }
   }
 
-  static const _name = 'ignite';
   static const _description = 'Ignite your projects with flame; '
       'a CLI scaffolding tool to create and setup your Flame projects.';
 }

--- a/lib/ignite_context.dart
+++ b/lib/ignite_context.dart
@@ -1,4 +1,4 @@
-import 'dart:io' show Directory, Process, ProcessResult;
+import 'dart:io';
 
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:mason/mason.dart';

--- a/lib/ignite_context.dart
+++ b/lib/ignite_context.dart
@@ -1,0 +1,34 @@
+import 'dart:io' show Directory, Process, ProcessResult;
+
+import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:mason/mason.dart';
+
+class IgniteContext {
+  const IgniteContext({
+    required this.logger,
+    required this.flameVersionManager,
+  });
+
+  final Logger logger;
+  final FlameVersionManager flameVersionManager;
+
+  Future<ProcessResult> run(
+    String executable,
+    List<String> arguments, {
+    String? workingDirectory,
+  }) {
+    return Process.run(
+      executable,
+      arguments,
+      workingDirectory: workingDirectory,
+    );
+  }
+
+  Future<MasonGenerator> generatorFromBundle(MasonBundle bundle) {
+    return MasonGenerator.fromBundle(bundle);
+  }
+
+  DirectoryGeneratorTarget createTarget(Directory directory) {
+    return DirectoryGeneratorTarget(directory);
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,7 +75,7 @@ Future<void> mainCommand(List<String> args) async {
   if (command?.name == 'create') {
     await createCommand(command!, logger);
   } else {
-    logger.err(
+    logger.info(
       'Invalid command. Please select an option, use --help for help.',
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,11 +3,14 @@ import 'package:completion/completion.dart' as completion;
 import 'package:ignite_cli/commands/create_command.dart';
 import 'package:ignite_cli/commands/version_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:mason_logger/mason_logger.dart';
 
 Future<void> mainCommand(List<String> args) async {
   await FlameVersionManager.init();
 
   final parser = ArgParser();
+  final logger = Logger();
+
   parser.addFlag('help', abbr: 'h', help: 'Displays this message.');
   parser.addFlag('version', abbr: 'v', help: 'Shows relevant version info.');
 
@@ -56,22 +59,24 @@ Future<void> mainCommand(List<String> args) async {
 
   final results = completion.tryArgsCompletion(args, parser);
   if (results['help'] as bool) {
-    print(parser.usage);
-    print('');
-    print('List of available commands:');
-    print('');
-    print('create:');
-    print('  ${create.usage}');
+    logger.info(parser.usage);
+    logger.info('');
+    logger.info('List of available commands:');
+    logger.info('');
+    logger.info('create:');
+    logger.info('  ${create.usage}');
     return;
   } else if (results['version'] as bool) {
-    await versionCommand();
+    await versionCommand(logger);
     return;
   }
 
   final command = results.command;
   if (command?.name == 'create') {
-    await createCommand(command!);
+    await createCommand(command!, logger);
   } else {
-    print('Invalid command. Please select an option, use --help for help.');
+    logger.err(
+      'Invalid command. Please select an option, use --help for help.',
+    );
   }
 }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,9 +29,10 @@ class IgniteCommandRunner extends CommandRunner<ExitCode> {
     );
   }
 
+  /// Forces commands added to [IgniteCommandRunner]
+  /// to use the [IgniteCommand] mixin on those commands.
   @override
-  void addCommand(covariant ContextProvider<ExitCode> command) {
-    // forces commands to use the [ContextProvider] mixin on any new commands
+  void addCommand(covariant IgniteCommand<ExitCode> command) {
     super.addCommand(command);
   }
 

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -29,10 +29,11 @@ class IgniteCommandRunner extends CommandRunner<ExitCode> {
     );
   }
 
-  /// Forces commands added to [IgniteCommandRunner]
-  /// to use the [IgniteCommand] mixin on those commands.
   @override
-  void addCommand(covariant IgniteCommand<ExitCode> command) {
+  void addCommand(Command<ExitCode> command) {
+    if (command is IgniteCommand) {
+      command.context = context;
+    }
     super.addCommand(command);
   }
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -2,6 +2,7 @@ import 'dart:io';
 
 import 'package:args/args.dart';
 import 'package:io/ansi.dart' as ansi;
+import 'package:io/io.dart';
 import 'package:mason_logger/mason_logger.dart' as logger;
 import 'package:path/path.dart' as p;
 
@@ -22,25 +23,26 @@ String getString(
   var value = results[name] as String?;
   if (!isInteractive) {
     if (value == null || value.isEmpty) {
-      print('Missing parameter $name is required.');
-      exit(1);
+      logger.err('Missing parameter $name is required.');
+      exit(ExitCode.usage.code);
     }
     final error = validate?.call(value);
     if (error != null) {
-      print('Invalid value $value provided: $error');
-      exit(1);
+      logger.err('Invalid value $value provided: $error');
+      exit(ExitCode.usage.code);
     }
   }
   while (value == null || value.isEmpty) {
     if (desc != null) {
-      stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
+      logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
 
     value = logger.prompt(message);
 
     // TODO(elijah): validation callback
+
     if (desc != null) {
-      stdout.write('\r\u{1B}[K');
+      logger.info('\r\u{1B}[K');
     }
   }
   return value;
@@ -64,27 +66,27 @@ String getOption(
       if (defaultsTo != null) {
         return defaultsTo;
       } else {
-        print('Missing parameter $name is required.');
-        exit(1);
+        logger.err('Missing parameter $name is required.');
+        exit(ExitCode.usage.code);
       }
     }
   }
   final fullValues = {...options, ...fullOptions}.values;
   if (value != null && !fullValues.contains(value)) {
-    print('Invalid value $value provided. Must be in: ${options.values}');
+    logger.err('Invalid value $value provided. Must be in: ${options.values}');
     value = null;
   }
 
   while (value == null) {
     if (desc != null) {
-      stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
+      logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
 
     final option = logger.chooseOne(message, choices: options.keys.toList());
     value = options[option];
 
     if (desc != null) {
-      stdout.write('\r\u{1B}[K');
+      logger.info('\r\u{1B}[K');
     }
   }
   return value;
@@ -119,8 +121,8 @@ List<String> getMultiOption(
       if (startingOptions.isNotEmpty) {
         return startingOptions;
       } else {
-        print('Missing parameter $name is required.');
-        exit(1);
+        logger.err('Missing parameter $name is required.');
+        exit(ExitCode.usage.code);
       }
     } else {
       return value;
@@ -128,17 +130,17 @@ List<String> getMultiOption(
   }
 
   if (value.any((e) => !options.contains(e))) {
-    print('Invalid value $value provided. Must be in: $options');
+    logger.err('Invalid value $value provided. Must be in: $options');
     value = [];
   }
   if (desc != null) {
-    stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
+    logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
   }
 
   value = logger.chooseAny(message, choices: options);
 
   if (desc != null) {
-    stdout.write('\r\u{1B}[K');
+    logger.info('\r\u{1B}[K');
   }
   return value;
 }

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -43,8 +43,7 @@ String getString(
 
     if (validation != null) {
       validation = logger.theme.warn(validation);
-      // omit the description on errors?
-      msg = '$message [$validation]';
+      msg = '$message [$validation]'; // omit the description on errors
     }
 
     value = logger.prompt(msg);

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,10 +1,9 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:charcode/ascii.dart' as ascii;
 import 'package:io/ansi.dart' as ansi;
+import 'package:mason_logger/mason_logger.dart' as logger;
 import 'package:path/path.dart' as p;
-import 'package:prompts/prompts.dart' as prompts;
 
 String getBundledFile(String name) {
   final binFolder = p.dirname(p.fromUri(Platform.script));
@@ -16,6 +15,7 @@ String getString(
   String name,
   String message, {
   required bool isInteractive,
+  required logger.Logger logger,
   String? desc,
   String? Function(String)? validate,
 }) {
@@ -35,21 +35,10 @@ String getString(
     if (desc != null) {
       stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
-    value = prompts.get(
-      message,
-      validate: (e) {
-        final error = validate?.call(e);
-        if (error != null) {
-          // clear the line
-          stdout.write('\n\r\u{1B}[K');
-          stdout.write(ansi.red.wrap('$error\u{1B}[1A\r'));
-          return false;
-        } else {
-          stdout.write('\n\r\u{1B}[K');
-          return true;
-        }
-      },
-    );
+
+    value = logger.prompt(message);
+
+    // TODO(elijah): validation callback
     if (desc != null) {
       stdout.write('\r\u{1B}[K');
     }
@@ -63,11 +52,13 @@ String getOption(
   String message,
   Map<String, String> options, {
   required bool isInteractive,
+  required logger.Logger logger,
   String? desc,
   String? defaultsTo,
   Map<String, String> fullOptions = const {},
 }) {
   var value = results[name] as String?;
+
   if (!isInteractive) {
     if (value == null) {
       if (defaultsTo != null) {
@@ -83,11 +74,15 @@ String getOption(
     print('Invalid value $value provided. Must be in: ${options.values}');
     value = null;
   }
+
   while (value == null) {
     if (desc != null) {
       stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
-    value = options[prompts.choose(message, options.keys)];
+
+    final option = logger.chooseOne(message, choices: options.keys.toList());
+    value = options[option];
+
     if (desc != null) {
       stdout.write('\r\u{1B}[K');
     }
@@ -114,6 +109,7 @@ List<String> getMultiOption(
   List<String> options, {
   required bool isInteractive,
   required bool isRequired,
+  required logger.Logger logger,
   List<String> startingOptions = const [],
   String? desc,
 }) {
@@ -130,6 +126,7 @@ List<String> getMultiOption(
       return value;
     }
   }
+
   if (value.any((e) => !options.contains(e))) {
     print('Invalid value $value provided. Must be in: $options');
     value = [];
@@ -137,90 +134,13 @@ List<String> getMultiOption(
   if (desc != null) {
     stdout.write(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
   }
-  final selectedOptions = value.isEmpty ? startingOptions : value;
-  value = cbx(message, options, selectedOptions);
+
+  value = logger.chooseAny(message, choices: options);
+
   if (desc != null) {
     stdout.write('\r\u{1B}[K');
   }
   return value;
-}
-
-List<String> cbx(
-  String message,
-  List<String> keys,
-  List<String> startingKeys,
-) {
-  final selected = startingKeys;
-  var hereIdx = 0;
-
-  var needsClear = false;
-  void writeIt() {
-    if (needsClear) {
-      for (var i = 0; i <= keys.length; i++) {
-        prompts.goUpOneLine();
-        prompts.clearLine();
-      }
-    } else {
-      needsClear = true;
-    }
-    print(message);
-    keys.asMap().forEach((index, option) {
-      final isSelected = selected.contains(option);
-      final isHere = index == hereIdx;
-      final text = ' ${isSelected ? '♦' : '♢'} $option';
-      final color = isHere ? ansi.cyan : ansi.darkGray;
-      print(color.wrap(text));
-    });
-  }
-
-  final oldEchoMode = stdin.echoMode;
-  final oldLineMode = stdin.lineMode;
-  while (true) {
-    int ch;
-    writeIt();
-
-    try {
-      stdin.lineMode = stdin.echoMode = false;
-      ch = stdin.readByteSync();
-
-      if (ch == ascii.$esc) {
-        ch = stdin.readByteSync();
-        if (ch == ascii.$lbracket) {
-          ch = stdin.readByteSync();
-          if (ch == ascii.$A) {
-            // Up key
-            hereIdx--;
-            if (hereIdx < 0) {
-              hereIdx = keys.length - 1;
-            }
-            writeIt();
-          } else if (ch == ascii.$B) {
-            // Down key
-            hereIdx++;
-            if (hereIdx >= keys.length) {
-              hereIdx = 0;
-            }
-            writeIt();
-          }
-        }
-      } else if (ch == ascii.$lf) {
-        // Enter key pressed - submit
-        return selected;
-      } else if (ch == ascii.$space) {
-        // Space key pressed - selected/unselect
-        final key = keys[hereIdx];
-        if (selected.contains(key)) {
-          selected.remove(key);
-        } else {
-          selected.add(key);
-        }
-        writeIt();
-      }
-    } finally {
-      stdin.lineMode = oldLineMode;
-      stdin.echoMode = oldEchoMode;
-    }
-  }
 }
 
 extension SortedBy<T> on Iterable<T> {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -23,12 +23,12 @@ String getString(
   var value = results[name] as String?;
   if (!isInteractive) {
     if (value == null || value.isEmpty) {
-      logger.err('Missing parameter $name is required.');
+      logger.info('Missing parameter $name is required.');
       exit(ExitCode.usage.code);
     }
     final error = validate?.call(value);
     if (error != null) {
-      logger.err('Invalid value $value provided: $error');
+      logger.info('Invalid value $value provided: $error');
       exit(ExitCode.usage.code);
     }
   }
@@ -66,14 +66,14 @@ String getOption(
       if (defaultsTo != null) {
         return defaultsTo;
       } else {
-        logger.err('Missing parameter $name is required.');
+        logger.info('Missing parameter $name is required.');
         exit(ExitCode.usage.code);
       }
     }
   }
   final fullValues = {...options, ...fullOptions}.values;
   if (value != null && !fullValues.contains(value)) {
-    logger.err('Invalid value $value provided. Must be in: ${options.values}');
+    logger.info('Invalid value $value provided. Must be in: ${options.values}');
     value = null;
   }
 
@@ -121,7 +121,7 @@ List<String> getMultiOption(
       if (startingOptions.isNotEmpty) {
         return startingOptions;
       } else {
-        logger.err('Missing parameter $name is required.');
+        logger.info('Missing parameter $name is required.');
         exit(ExitCode.usage.code);
       }
     } else {
@@ -130,7 +130,7 @@ List<String> getMultiOption(
   }
 
   if (value.any((e) => !options.contains(e))) {
-    logger.err('Invalid value $value provided. Must be in: $options');
+    logger.info('Invalid value $value provided. Must be in: $options');
     value = [];
   }
   if (desc != null) {

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,9 +1,7 @@
 import 'dart:io';
 
 import 'package:args/args.dart';
-import 'package:io/ansi.dart' as ansi;
-import 'package:io/io.dart';
-import 'package:mason_logger/mason_logger.dart' as logger;
+import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 
 String getBundledFile(String name) {
@@ -16,36 +14,31 @@ String getString(
   String name,
   String message, {
   required bool isInteractive,
-  required logger.Logger logger,
+  required Logger logger,
   String? desc,
   String? Function(String)? validate,
 }) {
-  var value = results[name] as String?;
+  final value = results[name] as String?;
   if (!isInteractive) {
     if (value == null || value.isEmpty) {
-      logger.info('Missing parameter $name is required.');
+      logger.err('Missing parameter $name is required.');
       exit(ExitCode.usage.code);
     }
     final error = validate?.call(value);
     if (error != null) {
-      logger.info('Invalid value $value provided: $error');
+      logger.err('Invalid value $value provided: $error');
       exit(ExitCode.usage.code);
     }
   }
-  while (value == null || value.isEmpty) {
-    if (desc != null) {
-      logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
-    }
 
-    value = logger.prompt(message);
+  desc = darkGray.wrap(desc);
+  var msg = message;
 
-    // TODO(elijah): validation callback
-
-    if (desc != null) {
-      logger.info('\r\u{1B}[K');
-    }
+  if (desc != null) {
+    msg = '$msg\n$desc';
   }
-  return value;
+
+  return logger.prompt(msg);
 }
 
 String getOption(
@@ -54,7 +47,7 @@ String getOption(
   String message,
   Map<String, String> options, {
   required bool isInteractive,
-  required logger.Logger logger,
+  required Logger logger,
   String? desc,
   String? defaultsTo,
   Map<String, String> fullOptions = const {},
@@ -79,7 +72,7 @@ String getOption(
 
   while (value == null) {
     if (desc != null) {
-      logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
+      logger.info(darkGray.wrap('\n$desc\u{1B}[1A\r'));
     }
 
     final option = logger.chooseOne(message, choices: options.keys.toList());
@@ -111,7 +104,7 @@ List<String> getMultiOption(
   List<String> options, {
   required bool isInteractive,
   required bool isRequired,
-  required logger.Logger logger,
+  required Logger logger,
   List<String> startingOptions = const [],
   String? desc,
 }) {
@@ -134,7 +127,7 @@ List<String> getMultiOption(
     value = [];
   }
   if (desc != null) {
-    logger.info(ansi.darkGray.wrap('\n$desc\u{1B}[1A\r'));
+    logger.info(darkGray.wrap('\n$desc\u{1B}[1A\r'));
   }
 
   value = logger.chooseAny(message, choices: options);

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -1,6 +1,6 @@
 import 'dart:io';
 
-import 'package:args/args.dart' show ArgResults;
+import 'package:args/args.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:path/path.dart' as p;
 

--- a/lib/utils.dart
+++ b/lib/utils.dart
@@ -60,45 +60,33 @@ String getOption(
   Map<String, String> options, {
   required bool isInteractive,
   required Logger logger,
-  String? desc,
   String? defaultsTo,
   Map<String, String> fullOptions = const {},
 }) {
-  var value = results[name];
+  var value = results[name]?.toString();
 
   if (!isInteractive) {
     if (value == null) {
       if (defaultsTo != null) {
         return defaultsTo;
       } else {
-        logger.info('Missing parameter $name is required.');
+        logger.err('Missing parameter $name is required.');
         exit(ExitCode.usage.code);
       }
     }
   }
   final fullValues = {...options, ...fullOptions}.values;
   if (value != null && !fullValues.contains(value)) {
-    logger.info('Invalid value $value provided. Must be in: ${options.values}');
+    logger.err('Invalid value $value provided. Must be in: ${options.values}');
     value = null;
   }
 
   while (value == null) {
-    if (desc != null) {
-      logger.info(darkGray.wrap('\n$desc\u{1B}[1A\r'));
-    }
-
     final option = logger.chooseOne(message, choices: options.keys.toList());
     value = options[option];
-
-    if (desc != null) {
-      logger.info('\r\u{1B}[K');
-    }
   }
-  return switch (value) {
-    final String value => value,
-    final bool value => 'true',
-    _ => '',
-  };
+
+  return value;
 }
 
 List<String> _unwrap(dynamic value) {
@@ -142,6 +130,7 @@ List<String> getMultiOption(
     logger.info('Invalid value $value provided. Must be in: $options');
     value = [];
   }
+
   if (desc != null) {
     logger.info(darkGray.wrap('\n$desc\u{1B}[1A\r'));
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -321,6 +321,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.0"
+  mocktail:
+    dependency: "direct dev"
+    description:
+      name: mocktail
+      sha256: "890df3f9688106f25755f26b1c60589a92b3ab91a22b8b224947ad041bf172d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.0.4"
   mustache_template:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -385,14 +385,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "5.0.3"
-  process_run:
-    dependency: "direct main"
-    description:
-      name: process_run
-      sha256: "6ec839cdd3e6de4685318e7686cd4abb523c3d3a55af0e8d32a12ae19bc66622"
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.2.4"
   pub_semver:
     dependency: transitive
     description:
@@ -489,14 +481,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
-  synchronized:
-    dependency: transitive
-    description:
-      name: synchronized
-      sha256: "0669c70faae6270521ee4f05bffd2919892d42d1276e6c495be80174b6bc0ef6"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.3.1"
   term_glyph:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -49,14 +49,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  charcode:
-    dependency: "direct main"
-    description:
-      name: charcode
-      sha256: fb0f1107cac15a5ea6ef0a6ef71a807b9e4267c713bb93e00e92d737cc8dbd8a
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.4.0"
   checked_yaml:
     dependency: transitive
     description:
@@ -97,14 +89,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.19.1"
-  completion:
-    dependency: "direct main"
-    description:
-      name: completion
-      sha256: f11b7a628e6c42b9edc9b0bc3aa490e2d930397546d2f794e8e1325909d11c60
-      url: "https://pub.dev"
-    source: hosted
-    version: "1.0.1"
   convert:
     dependency: transitive
     description:
@@ -234,7 +218,7 @@ packages:
     source: hosted
     version: "4.1.2"
   io:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: io
       sha256: dfd5a80599cf0165756e3181807ed3e77daf6dd4137caaad72d0b7931597650b
@@ -610,7 +594,7 @@ packages:
     source: hosted
     version: "5.12.0"
   yaml:
-    dependency: "direct main"
+    dependency: transitive
     description:
       name: yaml
       sha256: b9da305ac7c39faa3f030eccd175340f968459dae4af175130b3fc47e40d76ce

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -306,7 +306,7 @@ packages:
     source: hosted
     version: "0.1.2"
   mason_logger:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: mason_logger
       sha256: "6d5a989ff41157915cb5162ed6e41196d5e31b070d2f86e1c2edf216996a158c"
@@ -409,14 +409,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.2.4"
-  prompts:
-    dependency: "direct main"
-    description:
-      name: prompts
-      sha256: "3773b845e85a849f01e793c4fc18a45d52d7783b4cb6c0569fad19f9d0a774a1"
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.0.0"
   pub_semver:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -17,7 +17,6 @@ dependencies:
   mason: ^0.1.1
   mason_logger: ^0.3.3
   path: ^1.9.1
-  process_run: ^1.2.4
 
 dev_dependencies:
   dartdoc: ^8.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -22,4 +22,5 @@ dev_dependencies:
   dartdoc: ^8.0.2
   flame_lint: ^1.3.0
   mason_cli: ^0.1.2
+  mocktail: ^1.0.4
   test: ^1.24.9

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,16 +12,12 @@ environment:
 
 dependencies:
   args: ^2.7.0
-  charcode: ^1.4.0
-  completion: ^1.0.1
   dartlin: ^0.6.3
   http: ^1.3.0
-  io: ^1.0.5
   mason: ^0.1.1
   mason_logger: ^0.3.3
   path: ^1.9.1
   process_run: ^1.2.4
-  yaml: ^3.1.3
 
 dev_dependencies:
   dartdoc: ^8.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,9 +18,9 @@ dependencies:
   http: ^1.3.0
   io: ^1.0.5
   mason: ^0.1.1
+  mason_logger: ^0.3.3
   path: ^1.9.1
   process_run: ^1.2.4
-  prompts: ^2.0.0
   yaml: ^3.1.3
 
 dev_dependencies:

--- a/test/ignite_command_runner_test.dart
+++ b/test/ignite_command_runner_test.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 
-import 'package:ignite_cli/commands/ignite_command.dart';
 import 'package:ignite_cli/flame_version_manager.dart';
 import 'package:ignite_cli/ignite_command_runner.dart';
+import 'package:ignite_cli/ignite_context.dart';
 import 'package:ignite_cli/version.g.dart';
 import 'package:mason_logger/mason_logger.dart';
 import 'package:mocktail/mocktail.dart';

--- a/test/ignite_command_runner_test.dart
+++ b/test/ignite_command_runner_test.dart
@@ -12,45 +12,32 @@ class _MockLogger extends Mock implements Logger {}
 
 class _MockFlameVersionManager extends Mock implements FlameVersionManager {}
 
-class _MockIgniteProcess extends Mock implements IgniteProcess {}
-
 class _MockStdin extends Mock implements Stdin {}
 
 class _MockStdout extends Mock implements Stdout {}
 
-const usage =
-    '''Ignite your projects with Flame; a CLI scaffolding tool to create and setup your Flame projects.
-
-Usage: ignite <command> [arguments]
-
-Global options:
--h, --help            Print this usage information.
-    --[no-]verbose
-    --version         Print the current version.
-
-Available commands:
-  create   Create a new Flame project
-
-Run "ignite help <command>" for more information about a command.''';
+class _MockIgniteContext extends Mock implements IgniteContext {}
 
 void main() {
   group('IgniteCommandRunner', () {
     late Logger logger;
-    late IgniteProcess process;
     late IgniteCommandRunner commandRunner;
     late FlameVersionManager flameVersionManager;
     late Stdin stdin;
     late Stdout stdout; // ignore: close_sinks
+    late IgniteContext context;
 
     setUp(() {
       logger = _MockLogger();
       flameVersionManager = _MockFlameVersionManager();
-      process = _MockIgniteProcess();
       stdin = _MockStdin();
       stdout = _MockStdout();
+      context = _MockIgniteContext();
+      when(() => context.logger).thenReturn(logger);
+      when(() => context.flameVersionManager).thenReturn(flameVersionManager);
 
       when(
-        () => process.run(
+        () => context.run(
           any(),
           any(),
           workingDirectory: any(named: 'workingDirectory'),
@@ -61,13 +48,7 @@ void main() {
         Package.flame: const Versions(['1.28.1']),
       });
 
-      commandRunner = IgniteCommandRunner(
-        IgniteContext(
-          logger: logger,
-          flameVersionManager: flameVersionManager,
-          process: process,
-        ),
-      );
+      commandRunner = IgniteCommandRunner(context);
     });
 
     test('exits with code 0 when [version] is called', () async {
@@ -75,8 +56,8 @@ void main() {
       expect(exitCode, equals(ExitCode.success.code));
 
       verify(() => logger.info('ignite --version: $igniteVersion\n'));
-      verify(() => process.run('flutter', ['--version'])).called(1);
-      verify(() => process.run('dart', ['--version'])).called(1);
+      verify(() => context.run('flutter', ['--version'])).called(1);
+      verify(() => context.run('dart', ['--version'])).called(1);
       verifyNever(() => logger.err(any()));
     });
 

--- a/test/ignite_command_runner_test.dart
+++ b/test/ignite_command_runner_test.dart
@@ -1,0 +1,91 @@
+import 'dart:io';
+
+import 'package:ignite_cli/commands/ignite_command.dart';
+import 'package:ignite_cli/flame_version_manager.dart';
+import 'package:ignite_cli/ignite_command_runner.dart';
+import 'package:ignite_cli/version.g.dart';
+import 'package:mason_logger/mason_logger.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+class _MockLogger extends Mock implements Logger {}
+
+class _MockFlameVersionManager extends Mock implements FlameVersionManager {}
+
+class _MockIgniteProcess extends Mock implements IgniteProcess {}
+
+class _MockStdin extends Mock implements Stdin {}
+
+class _MockStdout extends Mock implements Stdout {}
+
+const usage =
+    '''Ignite your projects with Flame; a CLI scaffolding tool to create and setup your Flame projects.
+
+Usage: ignite <command> [arguments]
+
+Global options:
+-h, --help            Print this usage information.
+    --[no-]verbose
+    --version         Print the current version.
+
+Available commands:
+  create   Create a new Flame project
+
+Run "ignite help <command>" for more information about a command.''';
+
+void main() {
+  group('IgniteCommandRunner', () {
+    late Logger logger;
+    late IgniteProcess process;
+    late IgniteCommandRunner commandRunner;
+    late FlameVersionManager flameVersionManager;
+    late Stdin stdin;
+    late Stdout stdout; // ignore: close_sinks
+
+    setUp(() {
+      logger = _MockLogger();
+      flameVersionManager = _MockFlameVersionManager();
+      process = _MockIgniteProcess();
+      stdin = _MockStdin();
+      stdout = _MockStdout();
+
+      when(
+        () => process.run(
+          any(),
+          any(),
+          workingDirectory: any(named: 'workingDirectory'),
+        ),
+      ).thenAnswer((_) async => ProcessResult(0, 0, stdin, stdout));
+
+      when(() => flameVersionManager.versions).thenReturn({
+        Package.flame: const Versions(['1.28.1']),
+      });
+
+      commandRunner = IgniteCommandRunner(
+        IgniteContext(
+          logger: logger,
+          flameVersionManager: flameVersionManager,
+          process: process,
+        ),
+      );
+    });
+
+    test('exits with code 0 when [version] is called', () async {
+      final exitCode = await commandRunner.run(['--version']);
+      expect(exitCode, equals(ExitCode.success.code));
+
+      verify(() => logger.info('ignite --version: $igniteVersion\n'));
+      verify(() => process.run('flutter', ['--version'])).called(1);
+      verify(() => process.run('dart', ['--version'])).called(1);
+      verifyNever(() => logger.err(any()));
+    });
+
+    test('exits with code 0 when [verbose] is set', () async {
+      final exitCode = await commandRunner.run(['--verbose']);
+      expect(exitCode, equals(ExitCode.success.code));
+
+      verify(() => logger.level = Level.verbose).called(1);
+      verifyNever(() => logger.err(any()));
+    });
+  });
+}


### PR DESCRIPTION
I tried to decrease the imprint of any API changes (specifically, those in utils.dart). But I think it would be ideal if we could also use the other APIs of mason_logger for writing to stdout/stderr (err/info/detail/etc) methods.

should fix #12 and #14
